### PR TITLE
Ticket 276418,Nouvelles permissions/restrictions sur les champs des projets

### DIFF
--- a/lib/redmine_extended_workflows/controllers/projects_controller.rb
+++ b/lib/redmine_extended_workflows/controllers/projects_controller.rb
@@ -22,9 +22,10 @@ class ProjectsController < ApplicationController
     @rejected_fields_keys = all_params_keys - allowed_fields_keys
   end
 
+  # Override this method only in the cas of update project instead of override method  project/update
   # Renders a 200 response for partial successful updates
   def render_api_ok
-    if @rejected_fields_keys.count > 0
+    if params[:action] == "update" &&  @rejected_fields_keys.count > 0
       @messages = @rejected_fields_keys
       render :template => 'common/rejected_fields_messages.api', :status => 200, :layout => nil
     else

--- a/lib/redmine_extended_workflows/hooks.rb
+++ b/lib/redmine_extended_workflows/hooks.rb
@@ -7,6 +7,7 @@ module RedmineExtendedWorkflows
         require_relative 'helpers/workflows_helper'
         require_relative 'models/project'
         require_relative 'models/role'
+        require_relative 'models/custom_field'
       end
     end
 

--- a/lib/redmine_extended_workflows/models/custom_field.rb
+++ b/lib/redmine_extended_workflows/models/custom_field.rb
@@ -1,0 +1,10 @@
+require_dependency 'custom_field'
+
+class CustomField < ActiveRecord::Base
+
+  before_destroy :delete_workflow_projects_rules
+
+  def delete_workflow_projects_rules
+    WorkflowProject.where(:field_name => id).delete_all if type == "ProjectCustomField"
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -171,6 +171,7 @@ describe ProjectsController, type: :controller do
       expect(project.name).to eq(name_test)
       expect(project.description).to eq(description_test)
       expect(project.custom_field_values.first.value).to eq(field_test)
+      request.headers['Authorization'] = ''
     end
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -16,12 +16,17 @@ describe ProjectsController, type: :controller do
     @request.session[:user_id] = 2 # permissions are hard
   end
 
+  def setAuthorizationAPI(user, password = nil)
+    Setting.rest_api_enabled = '1'
+    request.headers['Authorization'] =  ActionController::HttpAuthentication::Basic.encode_credentials(user, password || user)
+  end
+
+
   describe "Update project" do
     let(:core_fields) { Project::CORE_FIELDS }
     let(:custom_fields) { CustomField.where(type: "ProjectCustomField" ) }
     let(:roles) { Role.sorted.select(&:consider_workflow?) }
     let(:project) { Project.find(1) }
-
     it "Should allow update all fields when user admin" do
       admin = User.find(1)
       User.current = admin
@@ -98,6 +103,74 @@ describe ProjectsController, type: :controller do
       expect(project.name).to eq(name_test)
       expect(project.description).to_not eq(description_test)
       expect(project.custom_field_values.first.value).to_not eq(field_test)
+    end
+  end
+
+  describe "Update project by API" do
+    let(:core_fields) { Project::CORE_FIELDS }
+    let(:custom_fields) { CustomField.where(type: "ProjectCustomField" ) }
+    let(:roles) { Role.sorted.select(&:consider_workflow?) }
+    let(:project) { Project.find(1) }
+
+    it "Should modify fields that are not designated as read-only for one of the assigned role(s) of user api" do
+      setAuthorizationAPI('jsmith', 'jsmith')
+      field_id = custom_fields.first.id
+      member = Member.find(1) # this member is with user_id 2 ,project_id1 ,and it has one role 1 manager.
+      member.roles << Role.find(2)
+      member.save
+
+
+      WorkflowProject.create(:role_id => 1, :field_name => "name", :rule => 'readonly')
+      WorkflowProject.create(:role_id => 1, :field_name => "description", :rule => 'readonly')
+      WorkflowProject.create(:role_id => 1, :field_name => "#{field_id}", :rule => 'readonly')
+
+      WorkflowProject.create(:role_id => 2, :field_name => "description", :rule => 'readonly')
+      WorkflowProject.create(:role_id => 2, :field_name => "#{field_id}", :rule => 'readonly')
+
+
+      name_test = "new_name"
+      description_test = "new_description"
+      field_test = "Beta"
+
+
+      patch :update, params: {
+        id: project.id,
+        project: { name: name_test, description: description_test, :custom_field_values => { "#{field_id}" => field_test } },
+        format: :json,
+      }
+
+
+      project.reload
+
+      expect(project.name).to eq(name_test)
+      expect(project.description).to_not eq(description_test)
+      expect(project.custom_field_values.first.value).to_not eq(field_test)
+    end
+    it "Should allow update all fields when user admin" do
+      User.current = User.find(1)
+      @request.session[:user_id] = 1
+      setAuthorizationAPI('admin', 'admin')
+
+      field_id = custom_fields.first.id
+
+      roles.each do |role|
+        WorkflowProject.create(:role_id => role.id, :field_name => "name", :rule => 'readonly')
+        WorkflowProject.create(:role_id => role.id, :field_name => "description", :rule => 'readonly')
+        WorkflowProject.create(:role_id => role.id, :field_name => "#{field_id}", :rule => 'readonly')
+      end
+
+      name_test = "new_name"
+      description_test = "new_description"
+      field_test = "Beta"
+
+      patch :update, params: { id: project.id,
+                      project: { name: name_test, description: description_test, :custom_field_values => { "#{field_id}" => field_test } }
+                    }
+      project.reload
+
+      expect(project.name).to eq(name_test)
+      expect(project.description).to eq(description_test)
+      expect(project.custom_field_values.first.value).to eq(field_test)
     end
   end
 end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -35,7 +35,7 @@ describe WatchersController, type: :controller do
       end
 
       custom_fields.each do |field|
-        expect(response.body).to have_selector("a", text: field )
+        expect(response.body).to have_selector("a", text: field.name )
       end
     end
 

--- a/spec/models/custom_field_spec.rb
+++ b/spec/models/custom_field_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "CustomField" do
+
+  fixtures :custom_fields, :roles
+
+  it "Update the table workflow_project in case of cascade deleting" do
+    field = CustomField.create(:name => 'Test',:type => 'ProjectCustomField', :field_format => 'string')
+    roles = Role.sorted.select(&:consider_workflow?)
+    WorkflowProject.create(:role_id => roles.first.id, :field_name => "#{field.id}", :rule => 'readonly')
+    WorkflowProject.create(:role_id => roles.last.id, :field_name => "#{field.id}", :rule => 'readonly')
+
+    expect do
+      field.destroy
+    end.to change { WorkflowProject.count }.by(-2)
+  end
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe "Role" do
+
+  fixtures :custom_fields, :roles
+
+  it "Update the table workflow_project in case of cascade deleting" do
+    custom_fields = CustomField.where(type: "ProjectCustomField" )
+    role_test = Role.create!(:name => 'Test')
+    role_test.add_permission! :add_issues
+
+    WorkflowProject.create(:role_id => role_test.id, :field_name => "#{custom_fields.first.id}", :rule => 'readonly')
+    WorkflowProject.create(:role_id => role_test.id, :field_name => "name", :rule => 'readonly')
+
+    expect do
+      role_test.destroy
+    end.to change { WorkflowProject.count }.by(-2)
+  end
+end


### PR DESCRIPTION
- Ajouter un nouvel onglet "Permissions sur les champs des projets" dans la page workfolw.
- Lister les champs standards et les champs personnalisés.
- Prendre en compte, les champs accessibles, en cas de modifier un projet.
- Test.