### PR TITLE
 prendre en compte juste les rôles qui ont la permission "Modifier les projets" dans l'onglet

### DIFF
--- a/app/views/workflows/projects.html.erb
+++ b/app/views/workflows/projects.html.erb
@@ -18,7 +18,7 @@
 <%= form_tag({}, :method => 'get') do %>
   <p>
     <label><%= l(:label_role) %>:
-      <%= options_for_workflow_select 'role_id[]', Role.sorted.select(&:consider_workflow?), @roles, :id => 'role_id', :class => 'expandable' %>
+      <%= options_for_workflow_select 'role_id[]', Role.sorted.select(&:workflow_project_roles?), @roles, :id => 'role_id', :class => 'expandable' %>
       <span class="toggle-multiselect icon-only"></span>
     </label>
     <%= submit_tag l(:button_edit), :name => nil %>

--- a/lib/redmine_extended_workflows/controllers/workflows_controller_concern.rb
+++ b/lib/redmine_extended_workflows/controllers/workflows_controller_concern.rb
@@ -4,7 +4,7 @@ module RedmineExtendedWorkflows::Controllers::WorkflowsControllerConcern
   extend ActiveSupport::Concern
 
   def projects
-    find_roles
+    find_update_project_roles
 
     if request.post? && @roles && params[:permissions]
       permissions = params[:permissions].deep_dup
@@ -22,6 +22,18 @@ module RedmineExtendedWorkflows::Controllers::WorkflowsControllerConcern
       @custom_fields = group_projects_custom_fields_by_section(@custom_fields) if Redmine::Plugin.installed?(:redmine_custom_fields_sections)
       @permissions = WorkflowProject.rules_by_roles(@roles)
     end
+  end
+
+  private 
+
+  def find_update_project_roles
+    ids = Array.wrap(params[:role_id])
+    if ids == ['all']
+      @roles = Role.sorted.select(&:workflow_project_roles?)
+    elsif ids.present?
+      @roles = Role.where(:id => ids).to_a
+    end
+    @roles = nil if @roles.blank?
   end
 end
 

--- a/lib/redmine_extended_workflows/models/project_patch.rb
+++ b/lib/redmine_extended_workflows/models/project_patch.rb
@@ -16,8 +16,8 @@ module RedmineExtendedWorkflows::Models
         end
 
         def self.get_read_only_attribute_for_roles(roles)
-          # Handle cases where roles lack permission to perform update/project.
-          workflow_roles_user = roles - Role.excluded_workflow_roles
+
+          workflow_roles_user = roles & Role.sorted.select(&:workflow_project_roles?)
 
           WorkflowProject.where(role: workflow_roles_user,
                                 rule: 'readonly')

--- a/lib/redmine_extended_workflows/models/role_patch.rb
+++ b/lib/redmine_extended_workflows/models/role_patch.rb
@@ -4,8 +4,8 @@ module RedmineExtendedWorkflows::Models
       base.class_eval do
         has_many :workflow_projects, :dependent => :destroy
 
-        def self.excluded_workflow_roles
-          Role.all - Role.sorted.select(&:consider_workflow?)
+        def workflow_project_roles?
+          has_permission?(:edit_project)
         end
       end
     end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -20,7 +20,7 @@ describe WatchersController, type: :controller do
 
     let(:core_fields) { Project::CORE_FIELDS }
     let(:custom_fields) { CustomField.where(type: "ProjectCustomField") }
-    let(:roles) { Role.sorted.select(&:consider_workflow?) }
+    let(:roles) { Role.sorted.select(&:workflow_project_roles?) }
 
     it "Should return a successful response for new tab projects" do
       get :projects

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -64,14 +64,14 @@ describe "Project" do
       expect(read_only_fields).to_not include("name")
     end
 
-    it "Should return all designated fields (as read-only) for all user roles when one of the roles is in excluded_workflow_roles" do
+    it "Should return all designated fields (as read-only) for all user roles when one of the roles is not in workflow_project_roles" do
       user = User.find(2)
       field_id = custom_fields.first.id
       Role.create!(:name => 'Test') # role does not have the persmission update project
 
       member = Member.find(1) # this member is with user_id 2 ,project_id1 ,and it has one role 1 manager.
       member.roles << Role.find(2)
-      member.roles << Role.excluded_workflow_roles.last
+      member.roles << Role.last
       member.save
 
       WorkflowProject.create(:role_id => 1, :field_name => "name", :rule => 'readonly')

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -16,4 +16,13 @@ describe "Role" do
       role_test.destroy
     end.to change { WorkflowProject.count }.by(-2)
   end
+
+  it "Should return the roles which have the permission edit_project" do
+    Role.create!(:name => 'Test')
+    roles = Role.select(&:workflow_project_roles?)
+    roles.each do |role|
+      expect(role.has_permission?(:edit_project)).to be_truthy
+    end
+    expect(roles).not_to include(Role.last)
+  end
 end


### PR DESCRIPTION
- Modification afin de prendre en compte juste les rôles qui ont la permission "Modifier les projets" dans l'onglet  "Permissions sur les champs des projets"